### PR TITLE
Add basic notifications

### DIFF
--- a/API/config/database_indexes_config.go
+++ b/API/config/database_indexes_config.go
@@ -10,6 +10,9 @@ const IdxReactionsPostID = `CREATE INDEX IF NOT EXISTS idx_reactions_post_id ON 
 const IdxReactionsCommentID = `CREATE INDEX IF NOT EXISTS idx_reactions_comment_id ON reactions(comment_id);`
 const IdxImagesPostID = `CREATE INDEX IF NOT EXISTS idx_images_post_id ON images(post_id);`
 
+// Notifications indexes
+const IdxNotificationsUserID = `CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);`
+
 // -- Index for faster lookups by provider and provider_user_id
 const CreateOAuthIndexes = `
 		CREATE INDEX IF NOT EXISTS idx_oauth_provider_user 

--- a/API/config/schema_config.go
+++ b/API/config/schema_config.go
@@ -106,3 +106,19 @@ const CreateOAuthTable = `CREATE TABLE IF NOT EXISTS oauth_accounts (
     -- Foreign key to link with existing user
     FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
 );`
+
+// Notifications table
+const CreateNotificationsTable = `CREATE TABLE IF NOT EXISTS notifications (
+        notification_id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        post_id TEXT,
+        comment_id TEXT,
+        type TEXT NOT NULL,
+        message TEXT,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        read_at TIMESTAMP,
+        deleted_at TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE,
+        FOREIGN KEY (post_id) REFERENCES posts(post_id) ON DELETE CASCADE,
+        FOREIGN KEY (comment_id) REFERENCES comments(comment_id) ON DELETE CASCADE
+    );`

--- a/API/handlers/notification_handler.go
+++ b/API/handlers/notification_handler.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"net/http"
+
+	"forum/middleware"
+	"forum/repository"
+	"forum/utils"
+)
+
+// NotificationHandler handles notification related endpoints
+
+type NotificationHandler struct {
+	Repo *repository.NotificationRepository
+}
+
+func NewNotificationHandler(repo *repository.NotificationRepository) *NotificationHandler {
+	return &NotificationHandler{Repo: repo}
+}
+
+// List returns notifications for the authenticated user
+func (h *NotificationHandler) List(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user := middleware.GetCurrentUser(r)
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	ns, err := h.Repo.GetByUser(user.ID)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to load notifications", http.StatusInternalServerError)
+		return
+	}
+	utils.JSONResponse(w, ns, http.StatusOK)
+}
+
+// MarkRead marks a single notification as read
+func (h *NotificationHandler) MarkRead(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user := middleware.GetCurrentUser(r)
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	id := utils.GetLastPathParam(r)
+	if id == "" {
+		utils.ErrorResponse(w, "Missing notification ID", http.StatusBadRequest)
+		return
+	}
+	if err := h.Repo.MarkRead(id); err != nil {
+		utils.ErrorResponse(w, "Failed to mark read", http.StatusInternalServerError)
+		return
+	}
+	utils.JSONResponse(w, map[string]string{"status": "read"}, http.StatusOK)
+}
+
+// MarkAllRead marks all notifications as read
+func (h *NotificationHandler) MarkAllRead(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user := middleware.GetCurrentUser(r)
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if err := h.Repo.MarkAllRead(user.ID); err != nil {
+		utils.ErrorResponse(w, "Failed to mark all read", http.StatusInternalServerError)
+		return
+	}
+	utils.JSONResponse(w, map[string]string{"status": "all read"}, http.StatusOK)
+}
+
+// Delete soft deletes a single notification
+func (h *NotificationHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user := middleware.GetCurrentUser(r)
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	id := utils.GetLastPathParam(r)
+	if id == "" {
+		utils.ErrorResponse(w, "Missing notification ID", http.StatusBadRequest)
+		return
+	}
+	if err := h.Repo.SoftDelete(id); err != nil {
+		utils.ErrorResponse(w, "Failed to delete", http.StatusInternalServerError)
+		return
+	}
+	utils.JSONResponse(w, map[string]string{"status": "deleted"}, http.StatusOK)
+}
+
+// DeleteAll soft deletes all notifications for the user
+func (h *NotificationHandler) DeleteAll(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user := middleware.GetCurrentUser(r)
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if err := h.Repo.SoftDeleteAll(user.ID); err != nil {
+		utils.ErrorResponse(w, "Failed to delete all", http.StatusInternalServerError)
+		return
+	}
+	utils.JSONResponse(w, map[string]string{"status": "all deleted"}, http.StatusOK)
+}

--- a/API/models/database_model.go
+++ b/API/models/database_model.go
@@ -14,7 +14,7 @@ import (
 
 // Database version constants
 const (
-	CURRENT_DB_VERSION = 5 // Updated to version 5 for nullable post/comment fields
+	CURRENT_DB_VERSION = 6 // Updated for notifications table
 	INITIAL_VERSION    = 1
 )
 
@@ -74,6 +74,14 @@ func GetMigrations() []Migration {
 				// 4. Rename new table
 				// Here, we just add a comment for manual migration
 				"-- Manual migration required: Make posts.title, posts.content, comments.content nullable.",
+			},
+		},
+		{
+			Version:     6,
+			Description: "Add notifications table",
+			SQL: []string{
+				config.CreateNotificationsTable,
+				config.IdxNotificationsUserID,
 			},
 		},
 		// Add future migrations here
@@ -183,7 +191,7 @@ func getDatabaseVersion(db *sql.DB) (int, error) {
 				}
 				return INITIAL_VERSION, nil
 			}
-			return 0, nil  // No version and no existing user table, implies brand new DB
+			return 0, nil // No version and no existing user table, implies brand new DB
 		}
 		return 0, fmt.Errorf("failed to get database version: %v", err)
 	}
@@ -283,13 +291,13 @@ func runMigrations(db *sql.DB) error {
 	if len(pending) == 0 && currentVersion == CURRENT_DB_VERSION {
 		fmt.Printf("Database is up to date (version %d)\n", currentVersion)
 		return nil
-		} else if len(pending) == 0 && currentVersion < CURRENT_DB_VERSION {
-			// This case means there are no migrations defined beyond the current version
-			// but the current version is not yet the latest expected version.
-			// This can happen if CURRENT_DB_VERSION constant is updated, but no
-			// corresponding migration is added to GetMigrations().
-			fmt.Printf("Warning: Database version (%d) is not at the latest expected version (%d), but no pending migrations found.\n", currentVersion, CURRENT_DB_VERSION)
-			return nil
+	} else if len(pending) == 0 && currentVersion < CURRENT_DB_VERSION {
+		// This case means there are no migrations defined beyond the current version
+		// but the current version is not yet the latest expected version.
+		// This can happen if CURRENT_DB_VERSION constant is updated, but no
+		// corresponding migration is added to GetMigrations().
+		fmt.Printf("Warning: Database version (%d) is not at the latest expected version (%d), but no pending migrations found.\n", currentVersion, CURRENT_DB_VERSION)
+		return nil
 	}
 
 	fmt.Printf("Running %d migration(s)...\n", len(pending))
@@ -348,6 +356,7 @@ func createTables(db *sql.DB) error {
 		config.CreateCommentsTable,
 		config.CreateReactionsTable,
 		config.CreateImagesTable,
+		config.CreateNotificationsTable,
 		config.CreatePostCategoriesTable,
 		config.CreateOAuthTable,
 		// Add OAuth state table for new installations
@@ -386,6 +395,7 @@ func createIndexes(db *sql.DB) error {
 		config.IdxReactionsPostID,
 		config.IdxReactionsCommentID,
 		config.IdxImagesPostID,
+		config.IdxNotificationsUserID,
 		// OAuth indexes
 		`CREATE INDEX IF NOT EXISTS idx_oauth_provider_user ON oauth_accounts(provider, provider_user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_oauth_user_id ON oauth_accounts(user_id)`,

--- a/API/models/notification.go
+++ b/API/models/notification.go
@@ -1,0 +1,20 @@
+package models
+
+import "time"
+
+// Notification represents a user notification
+// Type can be: comment_created, comment_edited, comment_deleted, reaction
+// PostID or CommentID reference the related object
+// DeletedAt is used for soft deletion
+
+type Notification struct {
+	ID        string     `json:"id"`
+	UserID    string     `json:"user_id"`
+	PostID    *string    `json:"post_id,omitempty"`
+	CommentID *string    `json:"comment_id,omitempty"`
+	Type      string     `json:"type"`
+	Message   string     `json:"message"`
+	CreatedAt time.Time  `json:"created_at"`
+	ReadAt    *time.Time `json:"read_at,omitempty"`
+	DeletedAt *time.Time `json:"-"`
+}

--- a/API/repository/comment_repository.go
+++ b/API/repository/comment_repository.go
@@ -60,3 +60,14 @@ func (r *CommentRepository) SoftDeleteComment(commentID string) error {
 	_, err := r.db.Exec(`UPDATE comments SET content = NULL, updated_at = ? WHERE comment_id = ?`, time.Now(), commentID)
 	return err
 }
+
+// GetByID returns a comment by its ID
+func (r *CommentRepository) GetByID(commentID string) (*models.Comment, error) {
+	var c models.Comment
+	err := r.db.QueryRow(`SELECT comment_id, post_id, user_id, content, created_at, updated_at FROM comments WHERE comment_id = ?`, commentID).
+		Scan(&c.ID, &c.PostID, &c.UserID, &c.Content, &c.CreatedAt, &c.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}

--- a/API/repository/notification_repository.go
+++ b/API/repository/notification_repository.go
@@ -1,0 +1,66 @@
+package repository
+
+import (
+	"database/sql"
+	"time"
+
+	"forum/models"
+	"forum/utils"
+)
+
+type NotificationRepository struct {
+	db *sql.DB
+}
+
+func NewNotificationRepository(db *sql.DB) *NotificationRepository {
+	return &NotificationRepository{db: db}
+}
+
+func (r *NotificationRepository) Create(n models.Notification) (*models.Notification, error) {
+	n.ID = utils.GenerateUUID()
+	n.CreatedAt = time.Now()
+	_, err := r.db.Exec(`INSERT INTO notifications (notification_id, user_id, post_id, comment_id, type, message, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		n.ID, n.UserID, n.PostID, n.CommentID, n.Type, n.Message, n.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &n, nil
+}
+
+func (r *NotificationRepository) GetByUser(userID string) ([]models.Notification, error) {
+	rows, err := r.db.Query(`SELECT notification_id, user_id, post_id, comment_id, type, message, created_at, read_at, deleted_at FROM notifications WHERE user_id = ? AND deleted_at IS NULL ORDER BY created_at DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ns []models.Notification
+	for rows.Next() {
+		var n models.Notification
+		if err := rows.Scan(&n.ID, &n.UserID, &n.PostID, &n.CommentID, &n.Type, &n.Message, &n.CreatedAt, &n.ReadAt, &n.DeletedAt); err != nil {
+			return nil, err
+		}
+		ns = append(ns, n)
+	}
+	return ns, nil
+}
+
+func (r *NotificationRepository) MarkRead(id string) error {
+	_, err := r.db.Exec(`UPDATE notifications SET read_at = ? WHERE notification_id = ?`, time.Now(), id)
+	return err
+}
+
+func (r *NotificationRepository) MarkAllRead(userID string) error {
+	_, err := r.db.Exec(`UPDATE notifications SET read_at = ? WHERE user_id = ? AND read_at IS NULL`, time.Now(), userID)
+	return err
+}
+
+func (r *NotificationRepository) SoftDelete(id string) error {
+	_, err := r.db.Exec(`UPDATE notifications SET deleted_at = ? WHERE notification_id = ?`, time.Now(), id)
+	return err
+}
+
+func (r *NotificationRepository) SoftDeleteAll(userID string) error {
+	_, err := r.db.Exec(`UPDATE notifications SET deleted_at = ? WHERE user_id = ? AND deleted_at IS NULL`, time.Now(), userID)
+	return err
+}

--- a/API/repository/post_repository.go
+++ b/API/repository/post_repository.go
@@ -39,6 +39,16 @@ func NewPostRepository(db *sql.DB) *PostRepository {
 	return &PostRepository{db: db}
 }
 
+// GetAuthorID returns the user_id of the author for the given post
+func (r *PostRepository) GetAuthorID(postID string) (string, error) {
+	var userID string
+	err := r.db.QueryRow(`SELECT user_id FROM posts WHERE post_id = ?`, postID).Scan(&userID)
+	if err != nil {
+		return "", err
+	}
+	return userID, nil
+}
+
 func (r *PostRepository) GetAllPosts() ([]models.Post, error) {
 	rows, err := r.db.Query(`
 		SELECT post_id, user_id, title, content, created_at, updated_at
@@ -191,7 +201,6 @@ func (r *PostRepository) GetCategoriesByPostID(postID string) ([]models.Category
 // 	}
 // 	return posts, nil
 // }
-
 
 func (r *PostRepository) GetPostsReactedByUser(userID string) ([]models.PostWithUser, error) {
 	query := `

--- a/API/repository/reaction_repository.go
+++ b/API/repository/reaction_repository.go
@@ -120,3 +120,25 @@ func (r *ReactionRepository) GetReactionsByCommentWithUser(commentID string) ([]
 	}
 	return reactions, nil
 }
+
+// GetReactionType returns the reaction type for a user on a given target or 0 if none exists
+func (r *ReactionRepository) GetReactionType(userID, targetType, targetID string) (int, error) {
+	switch targetType {
+	case "post":
+		var t int
+		err := r.db.QueryRow(`SELECT reaction_type FROM reactions WHERE user_id = ? AND post_id = ?`, userID, targetID).Scan(&t)
+		if err == sql.ErrNoRows {
+			return 0, nil
+		}
+		return t, err
+	case "comment":
+		var t int
+		err := r.db.QueryRow(`SELECT reaction_type FROM reactions WHERE user_id = ? AND comment_id = ?`, userID, targetID).Scan(&t)
+		if err == sql.ErrNoRows {
+			return 0, nil
+		}
+		return t, err
+	default:
+		return 0, errors.New("invalid target type")
+	}
+}

--- a/API/routes/routes.go
+++ b/API/routes/routes.go
@@ -20,6 +20,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	commentRepo := repository.NewCommentRepository(db)
 	reactionRepo := repository.NewReactionRepository(db)
 	imageRepo := repository.NewImageRepository(db)
+	notificationRepo := repository.NewNotificationRepository(db)
 
 	// Create handlers
 	authHandler := handlers.NewAuthHandler(userRepo, sessionRepo)
@@ -28,9 +29,10 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	postHandler := handlers.NewPostHandler(postRepo)
 	myPostsHandler := handlers.NewMyPostsHandler(postRepo, commentRepo, reactionRepo, imageRepo)
 	likedPostsHandler := handlers.NewLikedPostsHandler(postRepo, commentRepo, reactionRepo, imageRepo)
-	commentHandler := handlers.NewCommentHandler(commentRepo)
-	reactionHandler := handlers.NewReactionHandler(reactionRepo)
+	commentHandler := handlers.NewCommentHandler(commentRepo, postRepo, notificationRepo)
+	reactionHandler := handlers.NewReactionHandler(reactionRepo, postRepo, notificationRepo)
 	imageHandler := handlers.NewImageHandler(imageRepo)
+	notificationHandler := handlers.NewNotificationHandler(notificationRepo)
 	guestHandler := handlers.NewGuestHandler(categoryRepo, postRepo, commentRepo, reactionRepo, imageRepo)
 
 	// Create middleware
@@ -82,19 +84,26 @@ func SetupRoutes(db *sql.DB) http.Handler {
 
 	// Protected user routes
 	mux.Handle("/forum/api/posts/create", protected(http.HandlerFunc(postHandler.CreatePost)))
-	mux.Handle("/forum/api/posts/delete/", protected(http.HandlerFunc(postHandler.DeletePost))) // DELETE /forum/api/posts/delete/{id}
-	mux.Handle("/forum/api/posts/edit-title/", protected(http.HandlerFunc(postHandler.EditPostTitle))) // PUT /forum/api/posts/edit-title/{id}
+	mux.Handle("/forum/api/posts/delete/", protected(http.HandlerFunc(postHandler.DeletePost)))            // DELETE /forum/api/posts/delete/{id}
+	mux.Handle("/forum/api/posts/edit-title/", protected(http.HandlerFunc(postHandler.EditPostTitle)))     // PUT /forum/api/posts/edit-title/{id}
 	mux.Handle("/forum/api/posts/edit-content/", protected(http.HandlerFunc(postHandler.EditPostContent))) // PUT /forum/api/posts/edit-content/{id}
 	mux.Handle("/forum/api/user/posts", protected(http.HandlerFunc(myPostsHandler.GetMyPosts)))
 	mux.Handle("/forum/api/user/liked", protected(http.HandlerFunc(likedPostsHandler.GetLikedPosts)))
 	mux.Handle("/forum/api/user/disliked", protected(http.HandlerFunc(likedPostsHandler.GetDislikedPosts)))
 	mux.Handle("/forum/api/comments/create", protected(http.HandlerFunc(commentHandler.CreateComment)))
-	mux.Handle("/forum/api/comments/edit/", protected(http.HandlerFunc(commentHandler.EditComment))) // PUT /forum/api/comments/edit/{id}
+	mux.Handle("/forum/api/comments/edit/", protected(http.HandlerFunc(commentHandler.EditComment)))     // PUT /forum/api/comments/edit/{id}
 	mux.Handle("/forum/api/comments/delete/", protected(http.HandlerFunc(commentHandler.DeleteComment))) // DELETE /forum/api/comments/delete/{id}
 	mux.Handle("/forum/api/react", protected(http.HandlerFunc(reactionHandler.CreateReact)))
 	mux.Handle("/forum/api/images/upload", protected(http.HandlerFunc(imageHandler.Upload)))
 	mux.Handle("/forum/api/user/commented", protected(http.HandlerFunc(myPostsHandler.GetCommentedPosts)))
 	mux.Handle("/forum/api/images/delete/", protected(http.HandlerFunc(imageHandler.DeleteImagesByPost))) // DELETE /forum/api/images/delete/{post_id}
+
+	// Notification routes
+	mux.Handle("/forum/api/notifications", protected(http.HandlerFunc(notificationHandler.List)))
+	mux.Handle("/forum/api/notifications/read/", protected(http.HandlerFunc(notificationHandler.MarkRead))) // POST /forum/api/notifications/read/{id}
+	mux.Handle("/forum/api/notifications/read-all", protected(http.HandlerFunc(notificationHandler.MarkAllRead)))
+	mux.Handle("/forum/api/notifications/delete/", protected(http.HandlerFunc(notificationHandler.Delete))) // DELETE /forum/api/notifications/delete/{id}
+	mux.Handle("/forum/api/notifications/delete-all", protected(http.HandlerFunc(notificationHandler.DeleteAll)))
 
 	// Additional protected routes for user management
 	mux.Handle("/forum/api/user/profile", protected(http.HandlerFunc(authHandler.GetProfile)))

--- a/ui/static/css/user.css
+++ b/ui/static/css/user.css
@@ -733,3 +733,25 @@ body {
 .activity-dropdown-toggle.open .dropdown-arrow {
   transform: rotate(180deg);
 }
+
+/* Notification bell */
+#notification-bell.has-unread::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 8px;
+  height: 8px;
+  background: red;
+  border-radius: 50%;
+}
+
+.notification-list {
+  list-style: none;
+  padding: 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+.notification-list li {
+  margin-bottom: 0.5em;
+}

--- a/ui/static/js/user/user_notifications.js
+++ b/ui/static/js/user/user_notifications.js
@@ -1,0 +1,116 @@
+const bell = document.getElementById("notification-bell");
+const modal = document.getElementById("notification-modal");
+const closeBtn = modal.querySelector(".close-btn");
+const listEl = document.getElementById("notification-list");
+const markAllBtn = document.getElementById("mark-all-read");
+const deleteAllBtn = document.getElementById("delete-all");
+
+const sessionURL = "http://localhost:8080/forum/api/session/verify";
+
+let csrfToken = null;
+
+async function loadCSRFToken() {
+  try {
+    const resp = await fetch(sessionURL, { credentials: "include" });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    return data.csrf_token || data.CSRFToken;
+  } catch (err) {
+    console.error("csrf", err);
+    return null;
+  }
+}
+
+async function fetchNotifications() {
+  try {
+    const resp = await fetch("http://localhost:8080/forum/api/notifications", {
+      credentials: "include",
+    });
+    if (!resp.ok) return [];
+    return await resp.json();
+  } catch (err) {
+    console.error("load notifications", err);
+    return [];
+  }
+}
+
+function renderNotifications(ns) {
+  listEl.innerHTML = "";
+  if (ns.length === 0) {
+    listEl.innerHTML = "<li>No notifications</li>";
+    bell.classList.remove("has-unread");
+    return;
+  }
+  ns.forEach((n) => {
+    const li = document.createElement("li");
+    li.textContent = n.message;
+    li.dataset.id = n.id || n.ID;
+    li.addEventListener("click", () => markRead(li.dataset.id));
+    listEl.appendChild(li);
+  });
+  bell.classList.add("has-unread");
+}
+
+async function markRead(id) {
+  await loadCsrfIfNeeded();
+  await fetch(`http://localhost:8080/forum/api/notifications/read/${id}`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "X-CSRF-Token": csrfToken },
+  });
+  loadAndRender();
+}
+
+async function markAll() {
+  await loadCsrfIfNeeded();
+  await fetch("http://localhost:8080/forum/api/notifications/read-all", {
+    method: "POST",
+    credentials: "include",
+    headers: { "X-CSRF-Token": csrfToken },
+  });
+  loadAndRender();
+}
+
+async function deleteAll() {
+  await loadCsrfIfNeeded();
+  await fetch("http://localhost:8080/forum/api/notifications/delete-all", {
+    method: "DELETE",
+    credentials: "include",
+    headers: { "X-CSRF-Token": csrfToken },
+  });
+  loadAndRender();
+}
+
+async function loadCsrfIfNeeded() {
+  if (!csrfToken) {
+    csrfToken = await loadCSRFToken();
+  }
+}
+
+async function loadAndRender() {
+  const ns = await fetchNotifications();
+  renderNotifications(ns);
+}
+
+bell.addEventListener("click", async (e) => {
+  e.preventDefault();
+  modal.classList.remove("hidden");
+  await loadAndRender();
+});
+
+closeBtn.addEventListener("click", () => {
+  modal.classList.add("hidden");
+});
+
+markAllBtn.addEventListener("click", (e) => {
+  e.preventDefault();
+  markAll();
+});
+deleteAllBtn.addEventListener("click", (e) => {
+  e.preventDefault();
+  deleteAll();
+});
+
+window.addEventListener("click", (e) => {
+  if (e.target === modal) modal.classList.add("hidden");
+});

--- a/ui/static/templates/user/user_feed.html
+++ b/ui/static/templates/user/user_feed.html
@@ -10,11 +10,13 @@
     <script src="/static/js/user/user_mainpage.js" type="module"></script>
     <script src="/static/js/user/user_feed.js" type="module"></script>
     <script src="/static/js/user/create_post.js" defer></script>
+    <script src="/static/js/user/user_notifications.js" defer></script>
   </head>
   <body>
     <nav class="navbar">
       <a class="navbar-brand" href="/user/feed">Forum</a>
       <ul class="navbar-links">
+        <li><a href="#" id="notification-bell">🔔</a></li>
         <li><a href="#" id="logout-link">Logout</a></li>
       </ul>
     </nav>
@@ -32,9 +34,21 @@
         <li class="activity-dropdown-toggle">
           My Activity <span class="dropdown-arrow">&#9662;</span>
           <ul class="activity-dropdown-content">
-            <li><a href="/user/my-activity/my-posts" id="my-posts-link">My Posts</a></li>
-            <li><a href="/user/my-activity/my-comments" id="commented-posts-link">My Comments</a></li>
-            <li><a href="/user/my-activity/my-reactions" id="my-reactions-link">My Reactions</a></li>
+            <li>
+              <a href="/user/my-activity/my-posts" id="my-posts-link"
+                >My Posts</a
+              >
+            </li>
+            <li>
+              <a href="/user/my-activity/my-comments" id="commented-posts-link"
+                >My Comments</a
+              >
+            </li>
+            <li>
+              <a href="/user/my-activity/my-reactions" id="my-reactions-link"
+                >My Reactions</a
+              >
+            </li>
           </ul>
         </li>
       </ul>
@@ -113,6 +127,18 @@
           <label for="post-category" class="modal-label">Categories</label>
           <div id="post-category" class="checkbox-group"></div>
           <button id="submit-post">Submit</button>
+        </div>
+      </div>
+    </div>
+    <!-- Notifications Modal -->
+    <div id="notification-modal" class="modal hidden">
+      <div class="modal-content">
+        <div class="body-container">
+          <button class="close-btn">&times;</button>
+          <h2>Notifications</h2>
+          <ul id="notification-list" class="notification-list"></ul>
+          <button id="mark-all-read">Mark All Read</button>
+          <button id="delete-all">Delete All</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create notifications table and repository
- support notifications migrations and indexes
- post repo can fetch author of a post
- comment and reaction handlers generate notifications
- serve notifications through new REST endpoints
- add frontend bell icon and modal for notifications

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6884f82f66e48324baff140107737607