### PR TITLE
Add notification badge for unread count

### DIFF
--- a/ui/static/css/user_feed.css
+++ b/ui/static/css/user_feed.css
@@ -186,6 +186,20 @@ body, html {
 .notif-bell.lit {
   color: var(--color-accent);
 }
+.notif-item {
+  position: relative;
+}
+.notif-count {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  background: var(--color-accent);
+  color: #fff;
+  border-radius: 50%;
+  padding: 2px 5px;
+  font-size: 0.6em;
+  line-height: 1;
+}
 
 .notification-item {
   padding: 0.5em 0;

--- a/ui/static/js/user/notifications.js
+++ b/ui/static/js/user/notifications.js
@@ -1,6 +1,7 @@
 const bell = document.getElementById('notif-bell');
 const modal = document.getElementById('notification-modal');
 const list = document.getElementById('notif-list');
+const badge = document.getElementById('notif-count');
 const markAllBtn = document.getElementById('mark-all-read');
 const delAllBtn = document.getElementById('delete-all');
 const closeBtn = document.getElementById('close-notifications');
@@ -11,8 +12,13 @@ async function loadNotifications() {
     if (!resp.ok) throw new Error('failed');
     const data = await resp.json();
     render(data);
-    const hasUnread = data.some(n => !n.read_at && n.message);
+    const unreadCount = data.filter(n => !n.read_at && n.message).length;
+    const hasUnread = unreadCount > 0;
     bell.classList.toggle('lit', hasUnread);
+    if (badge) {
+      badge.textContent = unreadCount;
+      badge.classList.toggle('hidden', !hasUnread);
+    }
   } catch(e) { console.error(e); }
 }
 

--- a/ui/static/templates/user/user_feed.html
+++ b/ui/static/templates/user/user_feed.html
@@ -16,7 +16,10 @@
     <nav class="navbar">
       <a class="navbar-brand" href="/user/feed">Forum</a>
       <ul class="navbar-links">
-        <li><span id="notif-bell" class="notif-bell">🔔</span></li>
+        <li id="notif-item" class="notif-item">
+          <span id="notif-bell" class="notif-bell">🔔</span>
+          <span id="notif-count" class="notif-count hidden"></span>
+        </li>
         <li><a href="#" id="logout-link">Logout</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
## Summary
- inject a new badge element next to the notification bell
- style the badge
- compute unread count in `notifications.js` and update badge state

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_688511094cb0832482c1cfe33664917b