### PR TITLE
Enhance notification display

### DIFF
--- a/API/models/notification.go
+++ b/API/models/notification.go
@@ -4,14 +4,16 @@ import "time"
 
 // Notification represents a user notification
 type Notification struct {
-	ID        string     `json:"id"`
-	UserID    string     `json:"user_id"`
-	ActorID   string     `json:"actor_id,omitempty"`
-	PostID    *string    `json:"post_id,omitempty"`
-	CommentID *string    `json:"comment_id,omitempty"`
-	Type      string     `json:"type"`
-	Message   *string    `json:"message"`
-	CreatedAt time.Time  `json:"created_at"`
-	ReadAt    *time.Time `json:"read_at,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID             string     `json:"id"`
+	UserID         string     `json:"user_id"`
+	ActorID        string     `json:"actor_id,omitempty"`
+	PostID         *string    `json:"post_id,omitempty"`
+	CommentID      *string    `json:"comment_id,omitempty"`
+	Type           string     `json:"type"`
+	Message        *string    `json:"message"`
+	PostTitle      *string    `json:"post_title,omitempty"`
+	CommentSnippet *string    `json:"comment_snippet,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	ReadAt         *time.Time `json:"read_at,omitempty"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
 }

--- a/ui/static/css/user_feed.css
+++ b/ui/static/css/user_feed.css
@@ -188,11 +188,29 @@ body, html {
 }
 
 .notification-item {
-  padding: 0.5em 0;
-  border-bottom: 1px solid var(--bg-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 0.6em;
+  background: var(--bg-tertiary);
+  padding: 0.8em 1em;
+  border-radius: 8px;
+  margin-bottom: 0.5em;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .notification-item.unread {
-  font-weight: bold;
+  border-left: 4px solid var(--color-accent);
+}
+.notification-icon {
+  font-size: 1.2em;
+}
+.notif-link {
+  flex: 1;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+.notif-time {
+  font-size: 0.8em;
+  color: var(--text-muted);
 }
 .notif-actions {
   margin-top: 1em;

--- a/ui/static/js/user/notifications.js
+++ b/ui/static/js/user/notifications.js
@@ -23,10 +23,47 @@ function render(nots) {
     const div = document.createElement('div');
     div.className = 'notification-item';
     if (!n.read_at && n.message) div.classList.add('unread');
-    div.textContent = n.message || '(deleted)';
     div.dataset.id = n.id;
+
+    const icon = document.createElement('span');
+    icon.className = 'notification-icon';
+    icon.textContent = getIcon(n.type);
+
+    const link = document.createElement('a');
+    link.className = 'notif-link';
+    link.textContent = n.message || '(deleted)';
+    if (n.post_id) {
+      let url = `/user/post?id=${encodeURIComponent(n.post_id)}`;
+      if (n.comment_id) url += `#${encodeURIComponent(n.comment_id)}`;
+      link.href = url;
+    } else {
+      link.href = '#';
+    }
+
+    const time = document.createElement('time');
+    time.className = 'notif-time';
+    time.textContent = new Date(n.created_at).toLocaleString();
+
+    div.appendChild(icon);
+    div.appendChild(link);
+    div.appendChild(time);
     list.appendChild(div);
   });
+}
+
+function getIcon(type) {
+  switch (type) {
+    case 'comment':
+      return '💬';
+    case 'comment_edit':
+      return '✏️';
+    case 'comment_delete':
+      return '❌';
+    case 'reaction':
+      return '👍';
+    default:
+      return '🔔';
+  }
 }
 
 bell?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- extend notification model with post title and comment snippet
- join posts/comments when fetching notifications
- render notification timestamp and content links
- style notifications with icons and card layout

## Testing
- `go build ./...` in API module
- `go build ./cmd/main.go` in ui module

------
https://chatgpt.com/codex/tasks/task_e_68851115a7308324904af44848e8518d