### PR TITLE
Add notifications index

### DIFF
--- a/API/config/database_indexes_config.go
+++ b/API/config/database_indexes_config.go
@@ -13,6 +13,9 @@ const IdxImagesPostID = `CREATE INDEX IF NOT EXISTS idx_images_post_id ON images
 // Index for notifications table
 const IdxNotificationsUserID = `CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);`
 
+// Composite index for faster retrieval of notifications by user and creation time
+const IdxNotificationsUserCreated = `CREATE INDEX IF NOT EXISTS idx_notifications_user_created ON notifications(user_id, created_at);`
+
 // -- Index for faster lookups by provider and provider_user_id
 const CreateOAuthIndexes = `
 		CREATE INDEX IF NOT EXISTS idx_oauth_provider_user 

--- a/API/models/database_model.go
+++ b/API/models/database_model.go
@@ -14,7 +14,7 @@ import (
 
 // Database version constants
 const (
-	CURRENT_DB_VERSION = 5 // Updated to version 5 for nullable post/comment fields
+	CURRENT_DB_VERSION = 6 // Updated to version 6 for notifications composite index
 	INITIAL_VERSION    = 1
 )
 
@@ -75,6 +75,13 @@ func GetMigrations() []Migration {
 				// 4. Rename new table
 				// Here, we just add a comment for manual migration
 				"-- Manual migration required: Make posts.title, posts.content, comments.content nullable.",
+			},
+		},
+		{
+			Version:     6,
+			Description: "Add composite index on notifications(user_id, created_at)",
+			SQL: []string{
+				config.IdxNotificationsUserCreated,
 			},
 		},
 		// Add future migrations here
@@ -388,6 +395,7 @@ func createIndexes(db *sql.DB) error {
 		config.IdxReactionsPostID,
 		config.IdxReactionsCommentID,
 		config.IdxImagesPostID,
+		config.IdxNotificationsUserCreated,
 		// OAuth indexes
 		`CREATE INDEX IF NOT EXISTS idx_oauth_provider_user ON oauth_accounts(provider, provider_user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_oauth_user_id ON oauth_accounts(user_id)`,


### PR DESCRIPTION
## Summary
- add index constant for notifications by user and creation time
- run the new index during DB setup
- add migration version 6 for existing installs
- bump CURRENT_DB_VERSION to 6

## Testing
- `go test ./...` *(fails: build errors in middleware)*

------
https://chatgpt.com/codex/tasks/task_e_6885113083948324a9f51f00fcd1af36