### PR TITLE
Drop unused notifications index

### DIFF
--- a/API/config/database_indexes_config.go
+++ b/API/config/database_indexes_config.go
@@ -10,9 +10,6 @@ const IdxReactionsPostID = `CREATE INDEX IF NOT EXISTS idx_reactions_post_id ON 
 const IdxReactionsCommentID = `CREATE INDEX IF NOT EXISTS idx_reactions_comment_id ON reactions(comment_id);`
 const IdxImagesPostID = `CREATE INDEX IF NOT EXISTS idx_images_post_id ON images(post_id);`
 
-// Index for notifications table
-const IdxNotificationsUserID = `CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);`
-
 // Composite index for faster retrieval of notifications by user and creation time
 const IdxNotificationsUserCreated = `CREATE INDEX IF NOT EXISTS idx_notifications_user_created ON notifications(user_id, created_at);`
 

--- a/API/models/database_model.go
+++ b/API/models/database_model.go
@@ -58,7 +58,6 @@ func GetMigrations() []Migration {
 			SQL: []string{
 				config.CreateImagesTable,
 				config.IdxImagesPostID,
-				config.IdxNotificationsUserID,
 			},
 		},
 		{

--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ See `instructions.md` for more API usage examples.
 - CORS enabled for frontend-backend communication
 - Session management with secure cookies
 
+## Database Migration Notes
+
+If you're upgrading an existing database, the old index `idx_notifications_user_id`
+is no longer used. You can safely drop it with:
+
+```sql
+DROP INDEX IF EXISTS idx_notifications_user_id;
+```
+
 ---
 
 ## Contributing


### PR DESCRIPTION
## Summary
- remove `IdxNotificationsUserID` constant
- stop creating the old notification index during migration
- document how to drop the index for existing databases

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_688518205b088324bec4b290d5961f0f