### PR TITLE
Update notification modal scroll and UI states

### DIFF
--- a/ui/static/css/user_feed.css
+++ b/ui/static/css/user_feed.css
@@ -231,3 +231,14 @@ body, html {
   display: flex;
   gap: 1em;
 }
+
+/* Limit notification modal height to show latest items with internal scroll */
+#notification-modal .modal-content {
+  flex-direction: column;
+  max-height: 80vh;
+}
+
+#notif-list {
+  max-height: 400px; /* roughly 10 items */
+  overflow-y: auto;
+}

--- a/ui/static/js/user/notifications.js
+++ b/ui/static/js/user/notifications.js
@@ -122,6 +122,11 @@ markAllBtn?.addEventListener('click', async () => {
       'X-CSRF-Token': token || ''
     }
   });
+  bell.classList.remove('lit');
+  if (badge) {
+    badge.textContent = '0';
+    badge.classList.add('hidden');
+  }
   await loadNotifications();
 });
 
@@ -134,6 +139,12 @@ delAllBtn?.addEventListener('click', async () => {
       'X-CSRF-Token': token || ''
     }
   });
+  list.innerHTML = 'No notifications';
+  bell.classList.remove('lit');
+  if (badge) {
+    badge.textContent = '0';
+    badge.classList.add('hidden');
+  }
   await loadNotifications();
 });
 


### PR DESCRIPTION
## Summary
- update user feed CSS so notification modal scrolls and shows ~10 items
- ensure unread badge clears when marking all read
- clear list and badge after deleting all notifications

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_688784620a8c8324af3d142e7455f7ed