### PR TITLE
Add ownership checks for edits and deletes

### DIFF
--- a/API/handlers/comment_handler.go
+++ b/API/handlers/comment_handler.go
@@ -101,6 +101,15 @@ func (h *CommentHandler) EditComment(w http.ResponseWriter, r *http.Request) {
 		utils.ErrorResponse(w, "Nothing to update", http.StatusBadRequest)
 		return
 	}
+	ownerID, err := h.CommentRepo.GetCommentOwner(commentID)
+	if err != nil {
+		utils.ErrorResponse(w, "Comment not found", http.StatusNotFound)
+		return
+	}
+	if ownerID != user.ID {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	if err := h.CommentRepo.UpdateComment(commentID, req.Content); err != nil {
 		utils.ErrorResponse(w, "Failed to update comment", http.StatusInternalServerError)
 		return
@@ -132,6 +141,15 @@ func (h *CommentHandler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 	commentID := utils.GetLastPathParam(r)
 	if commentID == "" {
 		utils.ErrorResponse(w, "Missing comment ID", http.StatusBadRequest)
+		return
+	}
+	ownerID, err := h.CommentRepo.GetCommentOwner(commentID)
+	if err != nil {
+		utils.ErrorResponse(w, "Comment not found", http.StatusNotFound)
+		return
+	}
+	if ownerID != user.ID {
+		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 	if err := h.CommentRepo.SoftDeleteComment(commentID); err != nil {

--- a/API/middleware/auth_middleware.go
+++ b/API/middleware/auth_middleware.go
@@ -47,7 +47,7 @@ func (m *AuthMiddleware) Authenticate(next http.Handler) http.Handler {
 
 		if session.ExpiresAt.Before(time.Now()) {
 			// Scenario 3: Session found in DB, but its expiration time is in the past.
-			log.Printf("AuthMiddleware [DEBUG]: Session ID '%s' expired (UserID: %d) for request to %s", session.SessionID, session.UserID, r.URL.Path)
+			log.Printf("AuthMiddleware [DEBUG]: Session ID '%s' expired (UserID: %s) for request to %s", session.SessionID, session.UserID, r.URL.Path)
 			m.SessionRepo.DeleteBySessionID(session.SessionID)
 			m.clearSessionCookie(w) // Clear expired cookie
 			next.ServeHTTP(w, r)    // Proceed as unauthenticated
@@ -57,14 +57,14 @@ func (m *AuthMiddleware) Authenticate(next http.Handler) http.Handler {
 		user, err := m.UserRepo.GetByID(session.UserID)
 		if err != nil {
 			// Scenario 4: Session is valid, but the user it points to cannot be found.
-			log.Printf("AuthMiddleware [DEBUG]: User not found for session ID '%s' (UserID %d) for request to %s: %v", session.SessionID, session.UserID, r.URL.Path, err)
+			log.Printf("AuthMiddleware [DEBUG]: User not found for session ID '%s' (UserID %s) for request to %s: %v", session.SessionID, session.UserID, r.URL.Path, err)
 			m.clearSessionCookie(w) // Clear cookie, as session is invalid without a user
 			next.ServeHTTP(w, r)    // Proceed as unauthenticated
 			return
 		}
 
 		// Scenario 5: Authentication successful!
-		log.Printf("AuthMiddleware [INFO]: User '%s' (ID: %d) authenticated for request to %s", user.Username, user.ID, r.URL.Path)
+		log.Printf("AuthMiddleware [INFO]: User '%s' (ID: %s) authenticated for request to %s", user.Username, user.ID, r.URL.Path)
 		ctx := context.WithValue(r.Context(), "user", user)
 		ctx = context.WithValue(ctx, "session", session)
 		next.ServeHTTP(w, r.WithContext(ctx))

--- a/API/repository/comment_repository.go
+++ b/API/repository/comment_repository.go
@@ -11,6 +11,12 @@ type CommentRepository struct {
 	db *sql.DB
 }
 
+func (r *CommentRepository) GetCommentOwner(commentID string) (string, error) {
+	var userID string
+	err := r.db.QueryRow(`SELECT user_id FROM comments WHERE comment_id = ?`, commentID).Scan(&userID)
+	return userID, err
+}
+
 func (r *CommentRepository) GetByID(id string) (*models.Comment, error) {
 	var c models.Comment
 	err := r.db.QueryRow(`SELECT comment_id, post_id, user_id, content, created_at, updated_at FROM comments WHERE comment_id = ?`, id).


### PR DESCRIPTION
## Summary
- enforce ownership before updating or deleting posts/comments
- add repository method to fetch comment owner
- fix log formatting in auth middleware
- remove unused test file

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6887847d3d0083249964901d20b2bbf5