### PR TITLE
Show edit/delete only for post owner

### DIFF
--- a/ui/static/js/user/user_edit.js
+++ b/ui/static/js/user/user_edit.js
@@ -62,6 +62,9 @@ function renderSinglePostWithEdit(post) {
 
     // --- Deleted post check ---
     const { isDeleted, displayTitle, displayContent } = getPostDisplayState(post);
+
+    // Only the owner of the post can edit/delete it
+    const isOwner = currentUserId && post.user_id == currentUserId;
     
     // --- Add Delete control ---
     const controls = document.createElement('div');
@@ -317,18 +320,18 @@ function renderSinglePostWithEdit(post) {
     postBox.className = 'post';
 
     postBox.appendChild(title);
-    if (!isDeleted) postBox.appendChild(titleEditBtn);
-         postBox.appendChild(meta);
-      if (imageEl) postBox.appendChild(imageEl);
-     if (imageEl && !isDeleted) postBox.appendChild(imageEditBtn);
+    if (!isDeleted && isOwner) postBox.appendChild(titleEditBtn);
+    postBox.appendChild(meta);
+    if (imageEl) postBox.appendChild(imageEl);
+    if (imageEl && !isDeleted && isOwner) postBox.appendChild(imageEditBtn);
     if (!isDeleted) {
         postBox.appendChild(postContentCard);
-        postBox.appendChild(contentEditBtn);
+        if (isOwner) postBox.appendChild(contentEditBtn);
         postBox.appendChild(commentFormContainer);
     }
     postBox.appendChild(reactions);
     postBox.appendChild(categoryEl);
-    if (!isDeleted) {
+    if (!isDeleted && isOwner) {
         postBox.appendChild(deleteBtn);
     }
     postBox.appendChild(commentSection);


### PR DESCRIPTION
## Summary
- restrict post editing controls to the post owner

## Testing
- `go vet ./...` in API module
- `go vet ./...` in UI module

------
https://chatgpt.com/codex/tasks/task_e_688793cf8f508324a3188f0540f00f06