### PR TITLE
Disable soft delete for notifications

### DIFF
--- a/API/routes/routes.go
+++ b/API/routes/routes.go
@@ -103,8 +103,6 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	mux.Handle("/forum/api/user/notifications", protected(http.HandlerFunc(notificationHandler.GetUserNotifications)))
 	mux.Handle("/forum/api/notifications/read/", protected(http.HandlerFunc(notificationHandler.MarkRead))) // POST /forum/api/notifications/read/{id}
 	mux.Handle("/forum/api/notifications/read-all", protected(http.HandlerFunc(notificationHandler.MarkAllRead)))
-	mux.Handle("/forum/api/notifications/delete/", protected(http.HandlerFunc(notificationHandler.Delete))) // DELETE /forum/api/notifications/delete/{id}
-	mux.Handle("/forum/api/notifications/delete-all", protected(http.HandlerFunc(notificationHandler.DeleteAll)))
 
 	// Additional protected routes for user management
 	mux.Handle("/forum/api/user/profile", protected(http.HandlerFunc(authHandler.GetProfile)))

--- a/ui/static/js/user/notifications.js
+++ b/ui/static/js/user/notifications.js
@@ -3,7 +3,7 @@ const modal = document.getElementById('notification-modal');
 const list = document.getElementById('notif-list');
 const badge = document.getElementById('notif-count');
 const markAllBtn = document.getElementById('mark-all-read');
-const delAllBtn = document.getElementById('delete-all');
+const clearAllBtn = document.getElementById('clear-all');
 const closeBtn = document.getElementById('close-notifications');
 
 // Hold CSRF token for requests to the API
@@ -131,22 +131,13 @@ markAllBtn?.addEventListener('click', async () => {
   await loadNotifications();
 });
 
-delAllBtn?.addEventListener('click', async () => {
-  const token = await loadCSRFToken();
-  await fetch('http://localhost:8080/forum/api/notifications/delete-all', {
-    method: 'DELETE',
-    credentials: 'include',
-    headers: {
-      'X-CSRF-Token': token || ''
-    }
-  });
+clearAllBtn?.addEventListener('click', async () => {
   list.innerHTML = 'No notifications';
   bell.classList.remove('lit');
   if (badge) {
     badge.textContent = '0';
     badge.classList.add('hidden');
   }
-  await loadNotifications();
 });
 
 window.addEventListener('DOMContentLoaded', loadNotifications);

--- a/ui/static/templates/user/user_feed.html
+++ b/ui/static/templates/user/user_feed.html
@@ -129,7 +129,7 @@
         <div id="notif-list"></div>
         <div class="notif-actions">
           <button id="mark-all-read" class="btn secondary">Read All</button>
-          <button id="delete-all" class="btn ghost">Delete All</button>
+          <button id="clear-all" class="btn ghost">Clear All</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- drop delete routes for notifications
- rename `Delete All` button to `Clear All`
- remove backend calls and just clear in the UI modal

## Testing
- `go vet ./...` in `API`
- `go vet ./...` in `ui`

------
https://chatgpt.com/codex/tasks/task_e_6888cfd16f848324aebd988ee54da488